### PR TITLE
Fix EventEmitter inherits

### DIFF
--- a/lib/src/clientmongorpc.js
+++ b/lib/src/clientmongorpc.js
@@ -16,7 +16,7 @@
  */
 
 'use strict';
-var EventEmitter = require('events');
+var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
 var $mongo = module.exports = {};

--- a/lib/src/mongosubs.js
+++ b/lib/src/mongosubs.js
@@ -17,7 +17,7 @@
 
 'use strict';
 var util = require('util');
-var EventEmitter = require('events');
+var EventEmitter = require('events').EventEmitter;
 var EVENTS = ['insert', 'update', 'delete'];
 var QueryFilter = require('./queryfilter');
 

--- a/lib/test/mongosubsrpctest.js
+++ b/lib/test/mongosubsrpctest.js
@@ -17,7 +17,7 @@
 
 'use strict';
 var MongoSubsRpc = require('../src/mongosubsrpc');
-var EventEmitter = require('events');
+var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var expect = require('chai').expect;
 var sinon = require('sinon');


### PR DESCRIPTION
Now the tests are passing in node `v.10` Can't use the example for integration check as npm doesn't knows about path links.

fixes #10
