### PR TITLE
Can we add test for 'mongo.delete'

### DIFF
--- a/lib/test/clientmongosubstest.js
+++ b/lib/test/clientmongosubstest.js
@@ -44,7 +44,8 @@ describe('MongoSubs client', function() {
     var updateDoc = { name: 'tom', activity: 'sleep' };
     io.emit('mongo.insert', { tag: 'cartoon', result: insertDoc });
     io.emit('mongo.update', { tag: 'cartoon', result: updateDoc });
-
+    io.emit('mongo.delete', { _id: 123 });
+    
     expect(spyInsert.calledOnce).to.be.true;
     expect(spyInsert.getCall(0).args[0]).to.deep.equal(insertDoc);
     expect(spyUpdate.calledOnce).to.be.true;


### PR DESCRIPTION
it seems to fail on the latest version of the file. The 'delete' event never gets triggered, even though  it is correctly emitted by the server
